### PR TITLE
Switch from JsonObj[] to JsonObj.Path<T>

### DIFF
--- a/Background.cs
+++ b/Background.cs
@@ -90,18 +90,18 @@ namespace Kafe
 			if (!json.ContainsKey("rect"))
 				throw new MissingFieldException("Background layer must have a rect.");
 
-			Rect = RectangleExtensions.FromJson(json["rect"]);
+			Rect = json.Path<Rectangle>("/rect");
 
-			Origin = json.ContainsKey("origin") ? VectorExtensions.FromJson(json["origin"]) : Vector2.Zero;
+			Origin = json.Path<Vector2>("/origin", Vector2.Zero);
 
-			Parallax = json.ContainsKey("parallax") ? VectorExtensions.FromJson(json["parallax"]) : Vector2.One;
+			Parallax = json.Path<Vector2>("/parallax", Vector2.One);
 
-			Movement = json.ContainsKey("movement") ? VectorExtensions.FromJson(json["movement"]) : Vector2.Zero;
+			Movement = json.Path<Vector2>("/movement", Vector2.Zero);
 
 			if (json.ContainsKey("floor"))
 			{
 				Floor = (bool)json["floor"];
-				FloorVals = json.ContainsKey("floorVals") ? json.Path<int[]>("/floorVals") : new[] { 128, 128 };
+				FloorVals = json.Path<int[]>("/floorVals", new[] { 128, 182 });
 			}
 
 			Frames = new int[1] { 0 };
@@ -117,10 +117,10 @@ namespace Kafe
 						Frames[j] = j;
 				}
 			}
-			FrameRate = json.ContainsKey("rate") ? json.Path<int>("/rate") : 100;
+			FrameRate = json.Path<int>("/rate", 100);
 			frameTimeLeft = FrameRate;
 
-			BlendMode = json.ContainsKey("blend") ? json.Path<string>("/blend") : "none";
+			BlendMode = json.Path<string>("/blend", "none");
 		}
 
 		public void Update(GameTime gameTime)

--- a/Character.cs
+++ b/Character.cs
@@ -107,8 +107,8 @@ namespace Kafe
 		public void Reload(string jsonFile, int palIndex, bool refresh)
 		{
 			json = Mix.GetJson("fighters\\" + jsonFile, false) as JsonObj;
-			Name = json["name"] as string;
-			var baseName = json["base"] as string;
+			Name = json.Path<string>("/name");
+			var baseName = json.Path<string>("/base");
 
 			var keys = new string[json.Keys.Count];
 			json.Keys.CopyTo(keys, 0);
@@ -172,15 +172,11 @@ namespace Kafe
 
 			ColorSwap = palIndex;
 
-			animations = new List<JsonObj>();
-			foreach (var a in (List<object>)json["animations"])
-			{
-				animations.Add((JsonObj)a);
-			}
+			animations = json.Path<List<JsonObj>>("/animations");
 			if (!refresh)
-				animation = animations[0] as JsonObj;
+				animation = animations[0];
 			else
-				animation = animations[(int)currentAnim] as JsonObj;
+				animation = animations[(int)currentAnim];
 			Position = new Vector2(160, 160);
 			SetupFrames();
 			if (!refresh || currentFrame >= totalFrames)
@@ -192,10 +188,7 @@ namespace Kafe
 
 		public void SetupFrames()
 		{
-			frames = new List<JsonObj>();
-			foreach (var f in (List<object>)animation["frames"])
-				if (f is JsonObj)
-					frames.Add((JsonObj)f);
+			frames = animation.Path<List<JsonObj>>("/frames");
 			totalFrames = frames.Count;
 			boxes.Clear();
 			boxTypes.Clear();
@@ -206,12 +199,12 @@ namespace Kafe
 			var cF = frames[currentFrame];
 			if (cF.ContainsKey("img"))
 			{
-				var img = ((List<object>)cF["img"]);
-				var spriteIndex = (int)(double)img[0];
-				var image = (List<object>)((List<object>)json["sprites"])[spriteIndex];
-				Image = new Rectangle((int)(double)image[0], (int)(double)image[1], (int)(double)image[2], (int)(double)image[3]);
-				CelOffset = new Vector2((int)(double)img[1], (int)(double)img[2]);
-				FrameDelay = (int)(double)img[3];
+				var img = cF.Path<int[]>("/img");
+				var spriteIndex = img[0];
+				var image = json.Path<int[]>("/sprites/" + spriteIndex);
+				Image = new Rectangle(image[0], image[1], image[2], image[3]);
+				CelOffset = new Vector2(img[1], img[2]);
+				FrameDelay = img[3];
 
 				if (cF.ContainsKey("boxes"))
 				{
@@ -227,8 +220,8 @@ namespace Kafe
 			}
 			else
 			{
-				var image = ((List<object>)cF["image"]);
-				var offset = ((List<object>)cF["offset"]);
+				var image = cF.Path<int[]>("/image");
+				var offset = cF.Path<int[]>("/offset");
 				Image = new Rectangle((int)(double)image[0], (int)(double)image[1], (int)(double)image[2], (int)(double)image[3]);
 				CelOffset = new Vector2((int)(double)offset[0], (int)(double)offset[1]);
 				FrameDelay = 5;
@@ -340,7 +333,7 @@ namespace Kafe
 						{
 							if (animation["fallTo"] is List<object>)
 							{
-								var fallTos = ((List<object>)animation["fallTo"]);
+								var fallTos = animation.Path<object[]>("/fallTo");
 								if (EditMode)
 								{
 									if (fallTos[0] != null)
@@ -442,7 +435,7 @@ namespace Kafe
 					{
 						if (animation.ContainsKey("cancelTo"))
 						{
-							var cancelTos = ((List<object>)animation["cancelTo"]);
+							var cancelTos = animation.Path<object[]>("/cancelTo");
 							if (Controls.A && cancelTos[1] != null)
 								SwitchTo(cancelTos[1]);
 							else if (Controls.B && cancelTos[2] != null)
@@ -481,7 +474,7 @@ namespace Kafe
 			if (FrameDelay-- <= 0)
 			{
 				if (frames[currentFrame].ContainsKey("loop"))
-					currentFrame += (int)(double)frames[currentFrame]["loop"];
+					currentFrame += frames[currentFrame].Path<int>("/loop");
 
 				currentFrame++;
 				if (currentFrame >= totalFrames)
@@ -493,15 +486,9 @@ namespace Kafe
 
 				SetupImage();
 				if (frames[currentFrame].ContainsKey("impulse"))
-				{
-					var impulse = ((List<object>)frames[currentFrame]["impulse"]);
-					Velocity += new Vector2((float)(double)impulse[0], (float)(double)impulse[1]);
-				}
+					Velocity += VectorExtensions.FromJson(frames[currentFrame]["impulse"]);
 				else if (frames[currentFrame].ContainsKey("velocity"))
-				{
-					var velocity = ((List<object>)frames[currentFrame]["velocity"]);
-					Velocity = new Vector2((float)(double)velocity[0], (float)(double)velocity[1]);
-				}
+					Velocity = VectorExtensions.FromJson(frames[currentFrame]["velocity"]);
 			}
 
 			if (animation.ContainsKey("halt") && (bool)animation["halt"])
@@ -522,20 +509,6 @@ namespace Kafe
 			}
 
 			Position = new Vector2(Position.X + (FacingLeft ? -Velocity.X : Velocity.X), Position.Y);
-			/*
-			if (Velocity.X > 5)
-				Velocity -= new Vector2(2.5f, 0);
-			else if (Velocity.X > 1)
-				Velocity -= new Vector2(1, 0);
-			else if (Velocity.X > 0)
-				Velocity -= new Vector2(0.5f, 0);
-			if (Velocity.X < -5)
-				Velocity += new Vector2(2.5f, 0);
-			else if (Velocity.X < -1)
-				Velocity += new Vector2(1, 0);
-			else if (Velocity.X < 0)
-				Velocity += new Vector2(0.5f, 0);
-			*/
 
 			if (inputTimer > 0)
 			{
@@ -699,7 +672,7 @@ namespace Kafe
 			var control = Input.Controls[0];
 			if (cF.ContainsKey("img"))
 			{
-				var offset = ((List<object>)cF["img"]);
+				var offset = cF.Path<double[]>("/img");
 				if (control.TrgUp) offset[2] = (double)offset[2] + 1;
 				else if (control.TrgDown) offset[2] = (double)offset[2] - 1;
 				else if (control.TrgLeft) offset[1] = (double)offset[1] - 1;
@@ -708,7 +681,7 @@ namespace Kafe
 			}
 			else
 			{
-				var offset = ((List<object>)cF["offset"]);
+				var offset = cF.Path<double[]>("/offset");
 				if (control.TrgUp) offset[1] = (double)offset[1] + 1;
 				else if (control.TrgDown) offset[1] = (double)offset[1] - 1;
 				else if (control.TrgLeft) offset[0] = (double)offset[0] - 1;

--- a/Character.cs
+++ b/Character.cs
@@ -486,9 +486,9 @@ namespace Kafe
 
 				SetupImage();
 				if (frames[currentFrame].ContainsKey("impulse"))
-					Velocity += VectorExtensions.FromJson(frames[currentFrame]["impulse"]);
+					Velocity += frames[currentFrame].Path<Vector2>("/impulse");
 				else if (frames[currentFrame].ContainsKey("velocity"))
-					Velocity = VectorExtensions.FromJson(frames[currentFrame]["velocity"]);
+					Velocity = frames[currentFrame].Path<Vector2>("/velocity");
 			}
 
 			if (animation.ContainsKey("halt") && (bool)animation["halt"])

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -11,12 +11,6 @@ namespace Kafe
         {
             return new Vector2((int)vector.X, (int)vector.Y);
         }
-
-		public static Vector2 FromJson(object json)
-		{
-			var data = json as List<object>;
-			return new Vector2((float)(double)data[0], (float)(double)data[1]);
-		}
 	}
 
 	public static class RectangleExtensions
@@ -24,12 +18,6 @@ namespace Kafe
 		public static string ToShort(this Rectangle rect)
 		{
 			return string.Format("<{0},{1},{2},{3}>", rect.X, rect.Y, rect.Width, rect.Height);
-		}
-
-		public static Rectangle FromJson(object json)
-		{
-			var data = json as List<object>;
-			return new Rectangle((int)(double)data[0], (int)(double)data[1], (int)(double)data[2], (int)(double)data[3]);
 		}
 	}
 

--- a/Extensions.cs
+++ b/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 
@@ -10,13 +11,25 @@ namespace Kafe
         {
             return new Vector2((int)vector.X, (int)vector.Y);
         }
-    }
+
+		public static Vector2 FromJson(object json)
+		{
+			var data = json as List<object>;
+			return new Vector2((float)(double)data[0], (float)(double)data[1]);
+		}
+	}
 
 	public static class RectangleExtensions
 	{
 		public static string ToShort(this Rectangle rect)
 		{
 			return string.Format("<{0},{1},{2},{3}>", rect.X, rect.Y, rect.Width, rect.Height);
+		}
+
+		public static Rectangle FromJson(object json)
+		{
+			var data = json as List<object>;
+			return new Rectangle((int)(double)data[0], (int)(double)data[1], (int)(double)data[2], (int)(double)data[3]);
 		}
 	}
 

--- a/json/Kawa.Json.Path.cs
+++ b/json/Kawa.Json.Path.cs
@@ -74,6 +74,10 @@ namespace Kawa.Json
 				here = (int)(double)here;
 			else if (typeof(T).Name == "Int32[]" && here is List<object>)
 				here = ((List<object>)here).Select(x => (int)(double)x).ToArray();
+			else if (typeof(T).Name == "Double[]" && here is List<object>)
+				here = ((List<object>)here).Select(x => (double)x).ToArray();
+			else if (typeof(T).Name == "Object[]" && here is List<object>)
+				here = ((List<object>)here).ToArray();
 			else if (typeof(T).Name == "List`1")
 			{
 				var contained = typeof(T).GetGenericArguments()[0];
@@ -89,8 +93,11 @@ namespace Kawa.Json
 					case "String":
 						here = hereList.Select(x => (string)x).ToList();
 						break;
+					case "JsonObj":
+						here = hereList.Select(x => (JsonObj)x).ToList();
+						break;
 					default:
-						here = hereList.Select(x => (double)x).ToList();
+						here = hereList;
 						break;
 				}
 			}

--- a/json/Kawa.Json.Path.cs
+++ b/json/Kawa.Json.Path.cs
@@ -43,6 +43,13 @@ namespace Kawa.Json
 						throw new IndexOutOfRangeException();
 					here = list[index];
 				}
+				else if (isIndex && here is List<object>)
+				{
+					var list = (List<object>)here;
+					if (index < 0 || index >= list.Count)
+						throw new IndexOutOfRangeException();
+					here = list[index];
+				}
 				else if (here is JsonObj)
 				{
 					var map = (JsonObj)here;
@@ -60,6 +67,31 @@ namespace Kawa.Json
 				else
 				{
 					throw new JsonException("Current node is not an array or object, but path isn't done yet.");
+				}
+			}
+
+			if (typeof(T).Name == "Int32" && here is double)
+				here = (int)(double)here;
+			else if (typeof(T).Name == "Int32[]" && here is List<object>)
+				here = ((List<object>)here).Select(x => (int)(double)x).ToArray();
+			else if (typeof(T).Name == "List`1")
+			{
+				var contained = typeof(T).GetGenericArguments()[0];
+				var hereList = (List<object>)here;
+				switch (contained.Name)
+				{
+					case "Int32":
+						here = hereList.Select(x => (int)(double)x).ToList();
+						break;
+					case "Double":
+						here = hereList.Select(x => (double)x).ToList();
+						break;
+					case "String":
+						here = hereList.Select(x => (string)x).ToList();
+						break;
+					default:
+						here = hereList.Select(x => (double)x).ToList();
+						break;
 				}
 			}
 

--- a/json/Kawa.Json.Path.cs
+++ b/json/Kawa.Json.Path.cs
@@ -78,6 +78,10 @@ namespace Kawa.Json
 				here = ((List<object>)here).Select(x => (double)x).ToArray();
 			else if (typeof(T).Name == "Object[]" && here is List<object>)
 				here = ((List<object>)here).ToArray();
+			else if (typeof(T).Name == "Vector2" && here is List<object>)
+				here = new Microsoft.Xna.Framework.Vector2((float)(double)((List<object>)here)[0], (float)(double)((List<object>)here)[1]);
+			else if (typeof(T).Name == "Rectangle" && here is List<object>)
+				here = new Microsoft.Xna.Framework.Rectangle((int)(double)((List<object>)here)[0], (int)(double)((List<object>)here)[1], (int)(double)((List<object>)here)[2], (int)(double)((List<object>)here)[3]);
 			else if (typeof(T).Name == "List`1")
 			{
 				var contained = typeof(T).GetGenericArguments()[0];
@@ -105,6 +109,18 @@ namespace Kawa.Json
 			if (!(here is T))
 				throw new JsonException(string.Format("Value at end of path is not of the requested type -- found {0} but expected {1}.", here.GetType(), typeof(T)));
 			return (T)here;
+		}
+
+		public static T Path<T>(this JsonObj obj, string path, T replacement)
+		{
+			try
+			{
+				return Path<T>(obj, path);
+			}
+			catch (KeyNotFoundException)
+			{
+				return replacement;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
Involves more code to retrieve a given value, _but_ doesn't need those dumb double casts to get integers and such. Really cuts down on code on the usage side.